### PR TITLE
Handle join and leave events in initialize()

### DIFF
--- a/packages/coe/src/global.ts
+++ b/packages/coe/src/global.ts
@@ -75,11 +75,11 @@ export function initialize(params: InitializeParameters): void {
 		messageEventHandler.initialize(game);
 	}
 
-	game.join.add(p => {
-		if (p.player.id != null) addJoinedPlayer(p.player.id);
+	game.join.add(e => {
+		if (e.player.id != null) addJoinedPlayer(e.player.id);
 	});
-	game.leave.add(p => {
-		if (p.player.id != null) removeJoinedPlayer(p.player.id);
+	game.leave.add(e => {
+		if (e.player.id != null) removeJoinedPlayer(e.player.id);
 	});
 }
 

--- a/packages/coe/src/global.ts
+++ b/packages/coe/src/global.ts
@@ -41,6 +41,7 @@ export function getSessionId(): SessionId {
  */
 export function initialize(params: InitializeParameters): void {
 	const args: InitializeArguments | undefined = params.args && params.args.args ? params.args.args : undefined;
+	const game = params.game;
 	if (args && args.coe) {
 		if (args.coe.permission) {
 			permission.advance = !!args.coe.permission.advance;
@@ -54,25 +55,32 @@ export function initialize(params: InitializeParameters): void {
 			debugMode = !!args.coe.debugMode;
 		}
 	} else {
-		if (g.game.isActiveInstance()) {
+		if (game.isActiveInstance()) {
 			permission.advance = true;
 			permission.aggregation = true;
 			permission.advanceRequest = true;
 			roles = ["broadcaster"];
 		} else {
-			permission.advance = params.game.selfId == null;
-			permission.aggregation = params.game.selfId == null;
-			permission.advanceRequest = params.game.selfId == null;
+			permission.advance = game.selfId == null;
+			permission.aggregation = game.selfId == null;
+			permission.advanceRequest = game.selfId == null;
 		}
 	}
 
 	if (params.coeMessageEventHandler) {
-		params.coeMessageEventHandler.initialize(params.game);
+		params.coeMessageEventHandler.initialize(game);
 	} else {
 		// TODO: 相互参照の解消
 		const messageEventHandler = new COEMessageEventHandler();
-		messageEventHandler.initialize(params.game);
+		messageEventHandler.initialize(game);
 	}
+
+	game.join.add(p => {
+		if (p.player.id != null) addJoinedPlayer(p.player.id);
+	});
+	game.leave.add(p => {
+		if (p.player.id != null) removeJoinedPlayer(p.player.id);
+	});
 }
 
 /**

--- a/packages/coe/src/impl/Scene.ts
+++ b/packages/coe/src/impl/Scene.ts
@@ -1,4 +1,3 @@
-import { addJoinedPlayer, removeJoinedPlayer } from "../global";
 import { View } from "../View";
 import { BaseController } from "./BaseController";
 
@@ -105,18 +104,6 @@ export class Scene<Command, ActionData> extends g.Scene implements View<Command,
 					},
 					data: pev[3]
 				});
-			} else if (type === 0x00) {
-				// g.JoinEvent
-				if (playerId != null) {
-					addJoinedPlayer(playerId);
-				}
-				filtered.push(pev);
-			} else if (type === 0x01) {
-				// g.LeaveEvent
-				if (playerId != null) {
-					removeJoinedPlayer(playerId);
-				}
-				filtered.push(pev);
 			} else {
 				filtered.push(pev);
 			}


### PR DESCRIPTION
## このPullRequestが解決する内容
`g.JoinEvent` と `g.LeaveEvent` を `initilize()` 関数内でハンドルします。
これにより以下の仕様が加わります。
 * 「`g.Scene` を初期シーンとして利用した場合に `isJoinedPlayer()` が正しく判定できない」という制限が削除される
 * すべてのインスタンスで `isJoinedPlayer()` の判定が可能になる
