### PR TITLE
coeのビルドが失敗する問題への対応

### DIFF
--- a/packages/coe/package.json
+++ b/packages/coe/package.json
@@ -41,7 +41,7 @@
     "ts-jest": "^24.1.0",
     "tslint": "~5.20.0",
     "typedoc": "^0.15.0",
-    "typescript": "~3.6.3"
+    "typescript": "~3.9.2"
   },
   "dependencies": {
     "@akashic-environment/coe-plugin": "~2.0.0",


### PR DESCRIPTION
### 概要
coeのビルド時に以下のようなエラーが出てしまっていた。
```
../../node_modules/jest-diff/build/diffLines.d.ts(8,13): error TS1005: '=' expected.
../../node_modules/jest-diff/build/diffLines.d.ts(8,34): error TS1005: ';' expected.
../../node_modules/jest-diff/build/index.d.ts(10,13): error TS1005: '=' expected.
../../node_modules/jest-diff/build/index.d.ts(10,34): error TS1005: ';' expected.
../../node_modules/jest-diff/build/index.d.ts(11,1): error TS1128: Declaration or statement expected.
../../node_modules/jest-diff/build/index.d.ts(11,13): error TS1005: ';' expected.
../../node_modules/jest-diff/build/index.d.ts(11,52): error TS1005: ';' expected.
../../node_modules/jest-diff/build/printDiffs.d.ts(8,13): error TS1005: '=' expected.
../../node_modules/jest-diff/build/printDiffs.d.ts(8,57): error TS1005: ';' expected.
```

typescriptのバージョンを3.8.3にすれば直るとのことだったので、typescriptのバージョンを最新にしました(この問題を解決するためだけのバージョンアップなので最新ではなく3.8.3で留めておくべきかもしれませんが)。https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36299