### PR TITLE
npm run docが落ちていたので修正

### DIFF
--- a/packages/coe/package.json
+++ b/packages/coe/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^24.1.0",
     "tslint": "~5.20.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.7",
     "typescript": "~3.9.2"
   },
   "dependencies": {


### PR DESCRIPTION
### 概要
* typedocのバージョンが古いために`npm run doc`が落ちてしまっていたので、typedocのバージョンを最新にする対応を行いました。