### PR TITLE
publishスクリプトにタグ指定オプションを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "description": "A co-experience library for Akashic Engine",
   "scripts": {
     "postinstall": "lerna bootstrap",
-    "publish:patch": "lerna publish patch --dist-tag ${TARGET_TAG:-latest} --yes",
-    "publish:minor": "lerna publish minor --dist-tag ${TARGET_TAG:-latest} --yes",
-    "publish:major": "lerna publish major --dist-tag ${TARGET_TAG:-latest} --yes",
+    "publish:patch": "lerna publish patch --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
+    "publish:minor": "lerna publish minor --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
+    "publish:major": "lerna publish major --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
     "changelog": "echo \"# CHANGELOG\" > CHANGELOG.md && lerna-changelog --from=@akashic-extension/coe@1.0.0 >> CHANGELOG.md",
     "test": "lerna run test"
   },

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "description": "A co-experience library for Akashic Engine",
   "scripts": {
     "postinstall": "lerna bootstrap",
-    "publish:patch": "lerna publish patch --yes",
-    "publish:minor": "lerna publish minor --yes",
-    "publish:major": "lerna publish major --yes",
+    "publish:patch": "lerna publish patch --dist-tag ${TARGET_TAG:-latest} --yes",
+    "publish:minor": "lerna publish minor --dist-tag ${TARGET_TAG:-latest} --yes",
+    "publish:major": "lerna publish major --dist-tag ${TARGET_TAG:-latest} --yes",
     "changelog": "echo \"# CHANGELOG\" > CHANGELOG.md && lerna-changelog --from=@akashic-extension/coe@1.0.0 >> CHANGELOG.md",
     "test": "lerna run test"
   },


### PR DESCRIPTION
### 概要
* npm-scriptに記述している`publish:*`コマンドでこれまでタグの指定ができなかったので、環境変数を用いてタグの指定をできるようにしました。

### やったこと
* 環境変数`$PUBLISH_DIST_TAG`でpublish時のタグ名を指定できるようにしました
  * デフォルト値はlatest
  * このコマンドはwindows環境では動かないと思われますが、windows環境でpublishする想定は無いのでこの対応で十分ではと判断しました(問題がある場合は修正します)