### PR TITLE
Add types in tsconfig.json of coe-plugin

### DIFF
--- a/packages/coe-plugin/tsconfig.json
+++ b/packages/coe-plugin/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES5",
     "lib": ["es5"],
+    "types": [],
     "noImplicitAny": true,
     "module": "commonjs",
     "outDir": "./lib/",


### PR DESCRIPTION
submodule にした時に祖先ディレクトリの @types が入り込んでコンパイルエラーになることがあるので、明示的に制限します。型のみのモジュールなので `npm run build && npm run lint` が通って出力が正しいことのみ確認しています。

修正自明につきセルフマージします。
