### PR TITLE
add publish script as npm-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "description": "A co-experience library for Akashic Engine",
   "scripts": {
     "postinstall": "lerna bootstrap",
-    "publish:patch": "lerna publish patch --yes",
-    "publish:minor": "lerna publish minor --yes",
-    "publish:major": "lerna publish major --yes",
+    "publish:patch": "lerna publish patch --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
+    "publish:minor": "lerna publish minor --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
+    "publish:major": "lerna publish major --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
+    "publish:force-patch-all": "lerna publish patch --force-publish=* --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
+    "publish:prerelease": "lerna publish prerelease --dist-tag ${PUBLISH_DIST_TAG:-next} --yes",
+    "publish:from-package": "lerna publish from-package --dist-tag ${PUBLISH_DIST_TAG:-latest} --yes",
     "changelog": "echo \"# CHANGELOG\" > CHANGELOG.md && lerna-changelog --from=@akashic-extension/coe@1.0.0 >> CHANGELOG.md",
     "test": "lerna run test"
   },


### PR DESCRIPTION
### やったこと
* akashic-gamesの他のモノレポに合わせてnpm-scriptsに以下のものを追加
  * "publish:force-patch-all": 内容に変更点がなくても強制的にpatchバージョンを上げる
  * "publish:prerelease": beta.0などのプレリリースバージョンをpublishする
  * "publish:from-package": github上のpackage.jsonに記載されたversionでそのままpublish
    * 通常はgithub上のpackage.jsonとnpm上のversionを同時に上げるので利用しないが、github上のpackage.jsonのversionしか上がらない等トラブルが発生した時に利用する想定
* "publish:~"でタグが指定できない状態になっていたので環境変数PUBLISH_DIST_TAGを用いて指定できるようにした