### PR TITLE
Fix Scene#handleStateChange()

### DIFF
--- a/packages/coe/src/impl/Scene.ts
+++ b/packages/coe/src/impl/Scene.ts
@@ -132,7 +132,7 @@ export class Scene<Command, ActionData> extends g.Scene implements View<Command,
 	}
 
 	private handleStateChange(state?: g.SceneStateString): void {
-		if (state === "deactive" || state === "before-destroyed") {
+		if (state === "deactive") {
 			this.game.removeEventFilter(this.handleEventFilter_bound);
 		} else if (state === "active") {
 			this.game.addEventFilter(this.handleEventFilter_bound, true);


### PR DESCRIPTION
## 概要

`Scene#handleStateChange()`  の `removeEventFilter()` で undefined を呼んでる問題を修正。
if 文の条件 `state === "before-destroyed"` を削除

自明のためセルフマージとします。