### PR TITLE
Support BaseController#asset

### DIFF
--- a/packages/coe/src/impl/BaseController.ts
+++ b/packages/coe/src/impl/BaseController.ts
@@ -13,6 +13,10 @@ export class BaseController<Command, ActionData> implements Controller<Command, 
 	 */
 	assets: { [assetId: string]: g.Asset } = {};
 	/**
+	 * 本 Controller と紐づく Scene のアセットへのアクセサ。
+	 */
+	asset: g.AssetAccessor = new g.AssetAccessor(g.game._assetManager);
+	/**
 	 * 本 controller による g.MessageEvent の処理を一時的にロックするかどうか。
 	 *
 	 * 通常、ゲーム開発者は本値を参照・また書き換えてはならない。

--- a/packages/coe/src/impl/BaseController.ts
+++ b/packages/coe/src/impl/BaseController.ts
@@ -80,6 +80,7 @@ export class BaseController<Command, ActionData> implements Controller<Command, 
 		this.onActionReceive.destroy();
 
 		this.assets = null!;
+		this.asset = null!;
 		this.timerManager = null!;
 		this.broadcastDataBuffer = null!;
 		this.onUpdate = null!;


### PR DESCRIPTION
## 概要

Scene アセットへのアクセサ `BaseController#asset` (`g.AssetAccessor`)を追加します。

**動作確認**

サンプルコンテンツで controller#onActionReceived() 等の中でasset.getXxxxx() が利用できることを確認。